### PR TITLE
TGP-377: QA Fixes for invalid responses

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofiles/services/RouterService.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/services/RouterService.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpReads.is2xx
 import uk.gov.hmrc.tradergoodsprofiles.connectors.RouterConnector
 import uk.gov.hmrc.tradergoodsprofiles.models.errors.{RouterError, ServerErrorResponse}
-import uk.gov.hmrc.tradergoodsprofiles.models.requests.router.RouterUpdateRecordRequest
+import uk.gov.hmrc.tradergoodsprofiles.models.requests.router.{RouterCreateRecordRequest, RouterUpdateRecordRequest}
 import uk.gov.hmrc.tradergoodsprofiles.models.requests.{APICreateRecordRequest, UpdateRecordRequest, router}
 import uk.gov.hmrc.tradergoodsprofiles.models.response.{CreateOrUpdateRecordResponse, GetRecordResponse, GetRecordsResponse}
 

--- a/app/uk/gov/hmrc/tradergoodsprofiles/services/RouterService.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/services/RouterService.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpReads.is2xx
 import uk.gov.hmrc.tradergoodsprofiles.connectors.RouterConnector
 import uk.gov.hmrc.tradergoodsprofiles.models.errors.{RouterError, ServerErrorResponse}
-import uk.gov.hmrc.tradergoodsprofiles.models.requests.router.{RouterCreateRecordRequest, RouterUpdateRecordRequest}
+import uk.gov.hmrc.tradergoodsprofiles.models.requests.router.RouterUpdateRecordRequest
 import uk.gov.hmrc.tradergoodsprofiles.models.requests.{APICreateRecordRequest, UpdateRecordRequest, router}
 import uk.gov.hmrc.tradergoodsprofiles.models.response.{CreateOrUpdateRecordResponse, GetRecordResponse, GetRecordsResponse}
 

--- a/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/CreateRecordControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/CreateRecordControllerIntegrationSpec.scala
@@ -118,6 +118,52 @@ class CreateRecordControllerIntegrationSpec
       }
     }
 
+    "return BadRequest when Accept header is invalid" in {
+      withAuthorizedTrader()
+
+      val headers = Seq("X-Client-ID" -> "clientId", "Content-Type" -> "application/json")
+      val result  = await(
+        wsClient
+          .url(url)
+          .withHttpHeaders(headers: _*)
+          .post(requestBody)
+      )
+
+      result.status mustBe BAD_REQUEST
+      result.json mustBe createExpectedError(
+        "INVALID_HEADER_PARAMETER",
+        "Accept was missing from Header or is in wrong format",
+        4
+      )
+    }
+
+    "return BadRequest when Content-Type header is empty" in {
+      withAuthorizedTrader()
+
+      val headers = Seq("X-Client-ID" -> "clientId", "Content-Type" -> "", "Accept" -> "application/vnd.hmrc.1.0+json")
+      val result  = await(
+        wsClient
+          .url(url)
+          .withHttpHeaders(headers: _*)
+          .post(requestBody)
+      )
+
+      result.status mustBe UNSUPPORTED_MEDIA_TYPE
+    }
+
+    "return BadRequest when X-Client-ID header is missing" in {
+      withAuthorizedTrader()
+
+      val result = createRecordAndWaitWithoutClientIdHeader()
+
+      result.status mustBe BAD_REQUEST
+      result.json mustBe createExpectedError(
+        "INVALID_HEADER_PARAMETER",
+        "X-Client-ID was missing from Header or is in wrong format",
+        6000
+      )
+    }
+
     "return BadRequest for invalid request body" in {
       withAuthorizedTrader()
       val invalidRequestBody = Json.obj()

--- a/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/CreateRecordControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/CreateRecordControllerIntegrationSpec.scala
@@ -137,7 +137,7 @@ class CreateRecordControllerIntegrationSpec
       )
     }
 
-    "return BadRequest when Content-Type header is empty" in {
+    "return Unsupported media type when Content-Type header is empty or invalid" in {
       withAuthorizedTrader()
 
       val headers = Seq("X-Client-ID" -> "clientId", "Content-Type" -> "", "Accept" -> "application/vnd.hmrc.1.0+json")
@@ -149,6 +149,10 @@ class CreateRecordControllerIntegrationSpec
       )
 
       result.status mustBe UNSUPPORTED_MEDIA_TYPE
+      result.json mustBe Json.obj(
+        "statusCode" -> 415,
+        "message"    -> "Expecting text/json or application/json body"
+      )
     }
 
     "return BadRequest when X-Client-ID header is missing" in {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.22.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.1")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.2")


### PR DESCRIPTION
- [x] Included integration tests for invalid headers
- [x] Updated `uk.gov.hmrc.sbt-auto-build` to `3.22.0`

**Note: When we try to make a request with missing or invalid `Content-Type` the response will be `415 Unsupported Media Type` instead of `400 Bad Request`**

Expected response for invalid or empty `Content-Type`: 

```
{
    "statusCode": 415,
    "message": "Expecting text/json or application/json body"
}
```

---
**Ticket:** [TGP-377](https://jira.tools.tax.service.gov.uk/browse/TGP-377)