### PR TITLE
TGP-1235: only actorId should be mandatory

### DIFF
--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -515,12 +515,6 @@ components:
       type: object
       required:
         - actorId
-        - traderRef
-        - comcode
-        - goodsDescription
-        - countryOfOrigin
-        - category
-        - comcodeEffectiveFromDate
       properties:
         actorId:
           $ref: '#/components/schemas/actorId'


### PR DESCRIPTION
Update TGP record endpoint - set all the mandatory request body parameters to optional except for actorId