### PR TITLE
TGP-849: QA FIX - Removed correlationId from success header responses for all endpoints

### DIFF
--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -46,9 +46,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TGPRecordResponseSchema'
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/xCorrelationIdHdr'
         '400':
           description: Bad Request
           content:
@@ -130,9 +127,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TGPRecordResponseSchema'
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/xCorrelationIdHdr'
         '400':
           description: Bad Request
           content:
@@ -203,9 +197,6 @@ paths:
       responses:
         '200':
           description: OK;   Request completed successfully
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/xCorrelationIdHdr'
         '400':
           description: Bad Request
           content:
@@ -298,9 +289,6 @@ paths:
       responses:
         '201':
           description: TGP record was successfully submitted for advice
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/xCorrelationIdHdr'
         '400':
           description: Bad Request
           content:
@@ -362,9 +350,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MaintainProfileRecordResponse'
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/xCorrelationIdHdr'
         '400':
           description: Bad Request
           content:

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1177,14 +1177,6 @@ components:
       schema:
         $ref: '#/components/schemas/recordId'
       description: ID of the record for the TGP Product in the TGP Core database (UUID)
-  headers:
-    xCorrelationIdHdr:
-      description: A unique id created at source, i.e. client to TGP Digital.
-      required: true
-      schema:
-        type: string
-        format: uuid
-        example: 8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f
   examples:
     StandardBadRequestExample:
       value:


### PR DESCRIPTION
- [x] Removed `correlationId` from success header responses for all endpoints. The `correlationId` should be present only in the body of error responses.


---
**Ticket: [TGP-849](https://jira.tools.tax.service.gov.uk/browse/TGP-849)**