### PR TITLE
TGP-1315: QA Fixes for Remove Record Endpoint

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/RouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/RouterConnector.scala
@@ -91,7 +91,6 @@ class RouterConnector @Inject() (
 
       httpClient
         .delete(url"$url")
-        .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
         .withClientId
         .execute[HttpResponse]
     }

--- a/app/uk/gov/hmrc/tradergoodsprofiles/controllers/actions/ValidateHeaderAction.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/controllers/actions/ValidateHeaderAction.scala
@@ -59,7 +59,7 @@ class ValidateHeaderAction @Inject() (uuidService: UuidService)(implicit ec: Exe
       case _                                       => successful(false)
     }
 
-  private def invalidContentTypeResult                                        =
+  private def invalidContentTypeResult =
     Some(
       BadRequestErrorResponse(
         uuidService.uuid,
@@ -68,10 +68,16 @@ class ValidateHeaderAction @Inject() (uuidService: UuidService)(implicit ec: Exe
         InvalidHeaderContentType
       ).toResult
     )
+
   private def validateContentTypeHeader(request: Request[_]): Future[Boolean] =
-    request.headers.get(HeaderNames.CONTENT_TYPE) match {
-      case Some(header) if header.equals(MimeTypes.JSON) => successful(true)
-      case _                                             => successful(false)
+    request.method match {
+      case "DELETE" if request.uri.matches(".+/records/.+") =>
+        successful(true)
+      case _                                                =>
+        request.headers.get(HeaderNames.CONTENT_TYPE) match {
+          case Some(header) if header.equals(MimeTypes.JSON) => successful(true)
+          case _                                             => successful(false)
+        }
     }
 
   private def invalidClientIdResult =

--- a/app/uk/gov/hmrc/tradergoodsprofiles/controllers/actions/ValidateHeaderAction.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/controllers/actions/ValidateHeaderAction.scala
@@ -71,9 +71,9 @@ class ValidateHeaderAction @Inject() (uuidService: UuidService)(implicit ec: Exe
 
   private def validateContentTypeHeader(request: Request[_]): Future[Boolean] =
     request.method match {
-      case "DELETE" if request.uri.matches(".+/records/.+") =>
+      case "DELETE" =>
         successful(true)
-      case _                                                =>
+      case _        =>
         request.headers.get(HeaderNames.CONTENT_TYPE) match {
           case Some(header) if header.equals(MimeTypes.JSON) => successful(true)
           case _                                             => successful(false)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/utils/ApplicationConstants.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/utils/ApplicationConstants.scala
@@ -88,5 +88,5 @@ object ApplicationConstants {
   val InvalidOrMissingRequestorName                            = "Mandatory field requestorName was missing from body or is in the wrong format"
   val InvalidOrMissingRequestorEmailCode                       = 1009
   val InvalidOrMissingRequestorEmail                           = "Mandatory field requestorEmail was missing from body or is in the wrong format"
-  val InvalidActorIdQueryParameter                             = "Query parameter actorId is in the wrong format"
+  val InvalidActorIdQueryParameter                             = "Mandatory query parameter actorId was missing or is in the wrong format"
 }

--- a/app/uk/gov/hmrc/tradergoodsprofiles/utils/ValidationSupport.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/utils/ValidationSupport.scala
@@ -135,14 +135,16 @@ object ValidationSupport {
 
   val actorIdPattern: Regex = raw"[A-Z]{2}\d{12,15}".r
 
-  def validateActorId(actorId: String): Either[Error, String] =
-    if (actorIdPattern.matches(actorId)) Right(actorId)
-    else
-      Left(
-        Error(
-          InvalidRequestParameter,
-          InvalidActorIdQueryParameter,
-          InvalidActorId
+  def validateActorId(actorIdOpt: Option[String]): Either[Error, String] =
+    actorIdOpt match {
+      case Some(actorId) if actorIdPattern.matches(actorId) => Right(actorId)
+      case _                                                =>
+        Left(
+          Error(
+            InvalidRequestParameter,
+            InvalidActorIdQueryParameter,
+            InvalidActorId
+          )
         )
-      )
+    }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,7 +3,7 @@
 
 GET     /:eori/records/:recordId                    uk.gov.hmrc.tradergoodsprofiles.controllers.GetRecordsController.getRecord(eori: String, recordId: String)
 POST    /:eori/records                              uk.gov.hmrc.tradergoodsprofiles.controllers.CreateRecordController.createRecord(eori: String)
-DELETE  /:eori/records/:recordId                    uk.gov.hmrc.tradergoodsprofiles.controllers.RemoveRecordController.removeRecord(eori: String, recordId: String, actorId: String)
+DELETE  /:eori/records/:recordId                    uk.gov.hmrc.tradergoodsprofiles.controllers.RemoveRecordController.removeRecord(eori: String, recordId: String, actorId: Option[String])
 GET     /:eori/records                              uk.gov.hmrc.tradergoodsprofiles.controllers.GetRecordsController.getRecords(eori: String, lastUpdatedDate:Option[String] ?= None, page: Option[Int] ?= None, size: Option[Int] ?= None)
 PATCH   /:eori/records/:recordId                    uk.gov.hmrc.tradergoodsprofiles.controllers.UpdateRecordController.updateRecord(eori: String, recordId: String)
 POST    /:eori/records/:recordId/advice     uk.gov.hmrc.tradergoodsprofiles.controllers.RequestAdviceController.requestAdvice(eori: String, recordId: String)

--- a/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RemoveRecordControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RemoveRecordControllerIntegrationSpec.scala
@@ -234,7 +234,7 @@ class RemoveRecordControllerIntegrationSpec
       result.status mustBe BAD_REQUEST
       result.json mustBe createExpectedError(
         "INVALID_REQUEST_PARAMETER",
-        "Query parameter actorId is in the wrong format",
+        "Mandatory query parameter actorId was missing or is in the wrong format",
         8
       )
     }

--- a/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RemoveRecordControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RemoveRecordControllerIntegrationSpec.scala
@@ -112,7 +112,6 @@ class RemoveRecordControllerIntegrationSpec
       withClue("should add the right headers") {
         verify(
           deleteRequestedFor(urlEqualTo(routerUrl))
-            .withHeader("Content-Type", equalTo("application/json"))
             .withHeader("X-Client-ID", equalTo("clientId"))
         )
       }
@@ -287,7 +286,6 @@ class RemoveRecordControllerIntegrationSpec
         .withHttpHeaders(
           "X-Client-ID"  -> "clientId",
           "Accept"       -> "application/vnd.hmrc.1.0+json",
-          "Content-Type" -> "application/json"
         )
         .delete()
     )

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -183,7 +183,6 @@ paths:
       description: Remove a Trader's goods record
       operationId: removeTraderGoodsProfileRecord
       parameters:
-        - $ref: '#/components/parameters/Content-Type'
         - $ref: '#/components/parameters/Accept'
         - $ref: '#/components/parameters/Authorization'
         - $ref: '#/components/parameters/eoriParam'

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/RouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/RouterConnectorSpec.scala
@@ -210,8 +210,7 @@ class RouterConnectorSpec
       val expectedUrl =
         "http://localhost:23123/trader-goods-profiles-router/traders/eoriNumber/records/recordId?actorId=actorId"
       verify(httpClient).delete(eqTo(url"$expectedUrl"))(any)
-      verify(requestBuilder).setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-      verify(requestBuilder).setHeader("X-Client-ID"            -> "clientId")
+      verify(requestBuilder).setHeader("X-Client-ID" -> "clientId")
       verify(requestBuilder).execute(any, any)
 
       withClue("process the response within a timer") {

--- a/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RemoveRecordControllerSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RemoveRecordControllerSpec.scala
@@ -75,12 +75,12 @@ class RemoveRecordControllerSpec extends PlaySpec with AuthTestSupport with Befo
 
   "removeRecord" should {
     "return 204" in {
-      val result = sut.removeRecord(eoriNumber, recordId, actorId)(request)
+      val result = sut.removeRecord(eoriNumber, recordId, Some(actorId))(request)
       status(result) mustBe NO_CONTENT
     }
 
     "remove the record from router" in {
-      val result = sut.removeRecord(eoriNumber, recordId, actorId)(request)
+      val result = sut.removeRecord(eoriNumber, recordId, Some(actorId))(request)
 
       status(result) mustBe NO_CONTENT
       verify(routerService).removeRecord(eqTo(eoriNumber), eqTo(recordId), eqTo(actorId))(any)
@@ -89,35 +89,42 @@ class RemoveRecordControllerSpec extends PlaySpec with AuthTestSupport with Befo
     "return an error" when {
 
       "recordId is not a UUID" in {
-        val result = sut.removeRecord(eoriNumber, "1234-abc", actorId)(request)
+        val result = sut.removeRecord(eoriNumber, "1234-abc", Some(actorId))(request)
 
         status(result) mustBe BAD_REQUEST
         contentAsJson(result) mustBe createInvalidRequestParameterExpectedJson
       }
 
       "recordId is null" in {
-        val result = sut.removeRecord(eoriNumber, null, actorId)(request)
+        val result = sut.removeRecord(eoriNumber, null, Some(actorId))(request)
 
         status(result) mustBe BAD_REQUEST
         contentAsJson(result) mustBe createInvalidRequestParameterExpectedJson
       }
 
       "recordId is empty" in {
-        val result = sut.removeRecord(eoriNumber, " ", actorId)(request)
+        val result = sut.removeRecord(eoriNumber, " ", Some(actorId))(request)
 
         status(result) mustBe BAD_REQUEST
         contentAsJson(result) mustBe createInvalidRequestParameterExpectedJson
       }
 
       "actorId is invalid" in {
-        val result = sut.removeRecord(eoriNumber, recordId, invalidActorId)(request)
+        val result = sut.removeRecord(eoriNumber, recordId, Some(invalidActorId))(request)
 
         status(result) mustBe BAD_REQUEST
         contentAsJson(result) mustBe createInvalidActorIdExpectedJson
       }
 
       "actorId is empty" in {
-        val result = sut.removeRecord(eoriNumber, recordId, "")(request)
+        val result = sut.removeRecord(eoriNumber, recordId, Some(""))(request)
+
+        status(result) mustBe BAD_REQUEST
+        contentAsJson(result) mustBe createInvalidActorIdExpectedJson
+      }
+
+      "actorId is missing" in {
+        val result = sut.removeRecord(eoriNumber, recordId, None)(request)
 
         status(result) mustBe BAD_REQUEST
         contentAsJson(result) mustBe createInvalidActorIdExpectedJson
@@ -137,7 +144,7 @@ class RemoveRecordControllerSpec extends PlaySpec with AuthTestSupport with Befo
         when(routerService.removeRecord(any, any, any)(any))
           .thenReturn(Future.successful(Left(serviceError)))
 
-        val result = sut.removeRecord(eoriNumber, recordId, actorId)(request)
+        val result = sut.removeRecord(eoriNumber, recordId, Some(actorId))(request)
 
         status(result) mustBe INTERNAL_SERVER_ERROR
         contentAsJson(result) mustBe expectedJson


### PR DESCRIPTION
### Description 
- [x] Updated the `RemoveRecordController` to return the appropriate error message when the `actorId` query parameter is missing entirely from the request.
- [x] Included a test case for when the `actorId` is missing entirely.
- [x] Removed the `Content-Type` header from the RemoveRecord endpoint since it is not required for `DELETE` methods and we are not passing this header to the router.
- [x] Updated `ValidateHeaderAction`, making it endpoint-aware to not check the `Content-Type` for Remove Record requests.
- [x] Updated API spec and removed `Content-Type` from the remove endpoint
---
**Ticket:** [TGP-1315](https://jira.tools.tax.service.gov.uk/browse/TGP-1315)