### PR TITLE
TGP-1530: Add actorId to router RequestAdvice object and adjust the t…

### DIFF
--- a/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RequestAdviceIntegrationTest.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RequestAdviceIntegrationTest.scala
@@ -224,9 +224,9 @@ class RequestAdviceIntegrationTest
   def createRequestAdviceRequest: JsValue = Json
     .parse("""
              |{
-             |    "ukimsNumber": "Mr.Phil Edwards",
-             |    "nirmsNumber": "Phil.Edwards@gmail.com"
-             |
+             |    "actorId": "GB9876543210983",
+             |    "requestorName": "Mr.Phil Edwards",
+             |    "requestorEmail": "Phil.Edwards@gmail.com"
              |}
              |""".stripMargin)
 

--- a/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RequestAdviceControllerSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/controllers/RequestAdviceControllerSpec.scala
@@ -97,8 +97,9 @@ class RequestAdviceControllerSpec extends PlaySpec with AuthTestSupport with Bef
   def createRequestAdviceRequest: JsValue = Json
     .parse("""
              |{
-             |    "ukimsNumber": "Mr.Phil Edwards",
-             |    "nirmsNumber": "Phil.Edwards@gmail.com"
+             |    "actorId": "GB9876543210983",
+             |    "requestorName": "Mr.Phil Edwards",
+             |    "requestorEmail": "Phil.Edwards@gmail.com"
              |
              |}
              |""".stripMargin)


### PR DESCRIPTION
the actorId in the Get Record is the EORI of the last person to update that record, this is not necessarily the same as the EORI of the person making the Advice Request which is why I am adding back the actorId to the request body.