### PR TITLE
TGP-1585 Log messages must be at an appropriate level

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofiles/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/controllers/actions/AuthAction.scala
@@ -111,7 +111,7 @@ class AuthActionImpl @Inject() (
   }
 
   private def handleForbiddenError[A](eoriNumber: String)(implicit request: Request[A]): Future[Result] = {
-    logger.error(s"Forbidden error for ${request.uri}, eori number $eoriNumber")
+    logger.warn(s"Forbidden error for ${request.uri}, eori number $eoriNumber")
 
     Future.successful(
       ForbiddenErrorResponse(
@@ -134,7 +134,7 @@ class AuthActionImpl @Inject() (
     errorMessage: String
   )(implicit request: Request[A]): Result = {
 
-    logger.error(s"Unauthorised exception for ${request.uri} with error $errorMessage")
+    logger.warn(s"Unauthorised exception for ${request.uri} with error $errorMessage")
 
     UnauthorisedErrorResponse(
       uuidService.uuid,
@@ -146,7 +146,7 @@ class AuthActionImpl @Inject() (
     errorMessage: String
   )(implicit request: Request[A]): Result = {
 
-    logger.error(s"Unauthorised exception for ${request.uri} with error $errorMessage")
+    logger.warn(s"Unauthorised exception for ${request.uri} with error $errorMessage")
 
     UnauthorisedErrorResponse(
       uuidService.uuid,

--- a/app/uk/gov/hmrc/tradergoodsprofiles/services/RouterService.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/services/RouterService.scala
@@ -297,7 +297,7 @@ class RouterService @Inject() (
       case _                                       => ""
     }
 
-    logger.error(
+    logger.warn(
       s"[RouterService] - Error processing request $errorContext, status '${response.status}' with message: ${response.body}"
     )
     jsonAs[ErrorResponse](response.body)
@@ -321,7 +321,7 @@ class RouterService @Inject() (
         value.validate[T] match {
           case JsSuccess(v, _) => Right(v)
           case JsError(error)  =>
-            logger.error(
+            logger.warn(
               s"[RouterService] - Response body could not be read as type ${typeOf[T]}, error ${error.toString()}"
             )
             Left(
@@ -333,7 +333,7 @@ class RouterService @Inject() (
             )
         }
       case Failure(exception) =>
-        logger.error(
+        logger.warn(
           s"[RouterService] - Response body could not be parsed as JSON, body: $responseBody",
           exception
         )


### PR DESCRIPTION
In keeping with the recommendations from this guide - [Logging best practices](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=DTRG&title=Logging+best+practices#:~:text=data%20is%20PII.-,Use%20the%20appropriate%20log%20level,-Error%20%2D%20for%20significant), I have updated all issues related to unexpected response to a warn level log and only kept the error level log when a failure occurs during the api call