### PR TITLE
TGP-2010: Add Accept header in each connector that requests Router

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnector.scala
@@ -49,7 +49,7 @@ class AdviceRouterConnector @Inject() (
 
     httpClient
       .post(url"$url")
-      .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .withContentType
       .withAcceptHeader
       .withBody(Json.toJson(request.body))
       .withClientId

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnector.scala
@@ -50,7 +50,7 @@ class AdviceRouterConnector @Inject() (
     httpClient
       .post(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+      .withAcceptHeader
       .withBody(Json.toJson(request.body))
       .withClientId
       .execute(httpReaderWithoutResponseBody, ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnector.scala
@@ -50,6 +50,7 @@ class AdviceRouterConnector @Inject() (
     httpClient
       .post(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
       .withBody(Json.toJson(request.body))
       .withClientId
       .execute(httpReaderWithoutResponseBody, ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnector.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 import io.lemonlabs.uri.UrlPath
 import play.api.Logging
 import play.api.http.Status.INTERNAL_SERVER_ERROR
-import play.api.http.{HeaderNames, MimeTypes}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Request
 import uk.gov.hmrc.http.client.HttpClientV2

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/BaseConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/BaseConnector.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.tradergoodsprofiles.connectors
 
+import play.api.http.HeaderNames
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.RequestBuilder
 import uk.gov.hmrc.tradergoodsprofiles.utils.ApplicationConstants.XClientIdHeader
@@ -30,6 +31,14 @@ trait BaseConnector {
         case Some(header) => requestBuilder.setHeader(header)
         case None         => requestBuilder
       }
-  }
 
+    def withAcceptHeader(implicit hc: HeaderCarrier): RequestBuilder = {
+      val acceptHeader = hc.headers(Seq(HeaderNames.ACCEPT)).headOption
+      acceptHeader match {
+        case Some(header) => requestBuilder.setHeader(header)
+        case None         => requestBuilder
+      }
+    }
+
+  }
 }

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/BaseConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/BaseConnector.scala
@@ -40,5 +40,13 @@ trait BaseConnector {
       }
     }
 
+    def withContentType(implicit hc: HeaderCarrier): RequestBuilder = {
+      val acceptHeader = hc.headers(Seq(HeaderNames.CONTENT_TYPE)).headOption
+      acceptHeader match {
+        case Some(header) => requestBuilder.setHeader(header)
+        case None         => requestBuilder
+      }
+    }
+
   }
 }

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnector.scala
@@ -50,7 +50,7 @@ class CreateRecordRouterConnector @Inject() (
     httpClient
       .post(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+      .withAcceptHeader
       .withBody(createRecordRequest.body)
       .withClientId
       .execute(httpReader[CreateOrUpdateRecordResponse], ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnector.scala
@@ -50,6 +50,7 @@ class CreateRecordRouterConnector @Inject() (
     httpClient
       .post(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
       .withBody(createRecordRequest.body)
       .withClientId
       .execute(httpReader[CreateOrUpdateRecordResponse], ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnector.scala
@@ -49,7 +49,7 @@ class CreateRecordRouterConnector @Inject() (
 
     httpClient
       .post(url"$url")
-      .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .withContentType
       .withAcceptHeader
       .withBody(createRecordRequest.body)
       .withClientId

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnector.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 import io.lemonlabs.uri.UrlPath
 import play.api.Logging
 import play.api.http.Status.INTERNAL_SERVER_ERROR
-import play.api.http.{HeaderNames, MimeTypes}
 import play.api.libs.json.JsValue
 import play.api.mvc.Request
 import uk.gov.hmrc.http.client.HttpClientV2

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnector.scala
@@ -45,8 +45,8 @@ class GetRecordsRouterConnector @Inject() (
     val url = appConfig.routerUrl.withPath(routerGetRecordUrlPath(eori, recordId))
     httpClient
       .get(url"$url")
-      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
       .withClientId
+      .withAcceptHeader
       .execute(httpReader[GetRecordResponse], ec)
       .recover { case ex: Throwable =>
         logger.warn(
@@ -75,8 +75,8 @@ class GetRecordsRouterConnector @Inject() (
     val url = routerGetRecordsOptionalUrl(eori, lastUpdatedDate, page, size)
     httpClient
       .get(url"$url")
-      .setHeader("Accept" -> "application/vnd.hmrc.1.0+json")
       .withClientId
+      .withAcceptHeader
       .execute(httpReader[GetRecordsResponse], ec)
       .recover { case ex: Throwable =>
         logger.warn(

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnector.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 
 import io.lemonlabs.uri.UrlPath
 import play.api.Logging
+import play.api.http.HeaderNames
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
@@ -42,9 +43,9 @@ class GetRecordsRouterConnector @Inject() (
     hc: HeaderCarrier
   ): Future[Either[ServiceError, GetRecordResponse]] = {
     val url = appConfig.routerUrl.withPath(routerGetRecordUrlPath(eori, recordId))
-
     httpClient
       .get(url"$url")
+      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
       .withClientId
       .execute(httpReader[GetRecordResponse], ec)
       .recover { case ex: Throwable =>
@@ -72,8 +73,11 @@ class GetRecordsRouterConnector @Inject() (
     size: Option[Int] = None
   )(implicit hc: HeaderCarrier): Future[Either[ServiceError, GetRecordsResponse]] = {
     val url = routerGetRecordsOptionalUrl(eori, lastUpdatedDate, page, size)
+    println(s"HEADERRSSS  ---- $hc ---")
+
     httpClient
       .get(url"$url")
+      .setHeader("Accept" -> "application/vnd.hmrc.1.0+json")
       .withClientId
       .execute(httpReader[GetRecordsResponse], ec)
       .recover { case ex: Throwable =>

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnector.scala
@@ -73,8 +73,6 @@ class GetRecordsRouterConnector @Inject() (
     size: Option[Int] = None
   )(implicit hc: HeaderCarrier): Future[Either[ServiceError, GetRecordsResponse]] = {
     val url = routerGetRecordsOptionalUrl(eori, lastUpdatedDate, page, size)
-    println(s"HEADERRSSS  ---- $hc ---")
-
     httpClient
       .get(url"$url")
       .setHeader("Accept" -> "application/vnd.hmrc.1.0+json")

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnector.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 
 import io.lemonlabs.uri.UrlPath
 import play.api.Logging
-import play.api.http.HeaderNames
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnector.scala
@@ -50,7 +50,7 @@ class MaintainProfileRouterConnector @Inject() (
     httpClient
       .put(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+      .withAcceptHeader
       .withBody(updateProfileRequest.body)
       .withClientId
       .execute(httpReader[MaintainProfileResponse], ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnector.scala
@@ -49,7 +49,7 @@ class MaintainProfileRouterConnector @Inject() (
 
     httpClient
       .put(url"$url")
-      .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .withContentType
       .withAcceptHeader
       .withBody(updateProfileRequest.body)
       .withClientId

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnector.scala
@@ -50,6 +50,7 @@ class MaintainProfileRouterConnector @Inject() (
     httpClient
       .put(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
       .withBody(updateProfileRequest.body)
       .withClientId
       .execute(httpReader[MaintainProfileResponse], ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnector.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 import io.lemonlabs.uri.UrlPath
 import play.api.Logging
 import play.api.http.Status.INTERNAL_SERVER_ERROR
-import play.api.http.{HeaderNames, MimeTypes}
 import play.api.libs.json.JsValue
 import play.api.mvc.Request
 import uk.gov.hmrc.http.client.HttpClientV2

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/RemoveRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/RemoveRecordRouterConnector.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 
 import io.lemonlabs.uri.{QueryString, Url, UrlPath}
 import play.api.Logging
-import play.api.http.HeaderNames
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/RemoveRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/RemoveRecordRouterConnector.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 
 import io.lemonlabs.uri.{QueryString, Url, UrlPath}
 import play.api.Logging
+import play.api.http.HeaderNames
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
@@ -44,6 +45,7 @@ class RemoveRecordRouterConnector @Inject() (
 
     httpClient
       .delete(url"$url")
+      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
       .withClientId
       .execute(httpReaderWithoutResponseBody, ec)
       .recover { case ex: Throwable =>

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/RemoveRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/RemoveRecordRouterConnector.scala
@@ -45,7 +45,7 @@ class RemoveRecordRouterConnector @Inject() (
 
     httpClient
       .delete(url"$url")
-      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+      .withAcceptHeader
       .withClientId
       .execute(httpReaderWithoutResponseBody, ec)
       .recover { case ex: Throwable =>

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnector.scala
@@ -49,7 +49,7 @@ class UpdateRecordRouterConnector @Inject() (
     val url = appConfig.routerUrl.withPath(routerUpdateRecordUrlPath(eori, recordId))
     httpClient
       .patch(url"$url")
-      .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .withContentType
       .withAcceptHeader
       .withBody(updateRecordRequest.body)
       .withClientId

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnector.scala
@@ -50,6 +50,7 @@ class UpdateRecordRouterConnector @Inject() (
     httpClient
       .patch(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
       .withBody(updateRecordRequest.body)
       .withClientId
       .execute(httpReader[CreateOrUpdateRecordResponse], ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnector.scala
@@ -50,7 +50,7 @@ class UpdateRecordRouterConnector @Inject() (
     httpClient
       .patch(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+      .withAcceptHeader
       .withBody(updateRecordRequest.body)
       .withClientId
       .execute(httpReader[CreateOrUpdateRecordResponse], ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnector.scala
@@ -19,11 +19,10 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 import io.lemonlabs.uri.UrlPath
 import play.api.Logging
 import play.api.http.Status.INTERNAL_SERVER_ERROR
-import play.api.http.{HeaderNames, MimeTypes}
 import play.api.libs.json.JsValue
 import play.api.mvc.Request
-import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
 import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
 import uk.gov.hmrc.tradergoodsprofiles.config.AppConfig
 import uk.gov.hmrc.tradergoodsprofiles.models.errors.{ErrorResponse, ServiceError}
 import uk.gov.hmrc.tradergoodsprofiles.models.response.CreateOrUpdateRecordResponse

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnector.scala
@@ -49,7 +49,7 @@ class WithdrawAdviceRouterConnector @Inject() (
     httpClient
       .put(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+      .withAcceptHeader
       .withBody(Json.toJson(request.body))
       .withClientId
       .execute(httpReaderWithoutResponseBody, ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnector.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.tradergoodsprofiles.connectors
 
 import io.lemonlabs.uri.UrlPath
 import play.api.Logging
-import play.api.http.{HeaderNames, MimeTypes}
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Request

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnector.scala
@@ -49,6 +49,7 @@ class WithdrawAdviceRouterConnector @Inject() (
     httpClient
       .put(url"$url")
       .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .setHeader(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
       .withBody(Json.toJson(request.body))
       .withClientId
       .execute(httpReaderWithoutResponseBody, ec)

--- a/app/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnector.scala
@@ -48,7 +48,7 @@ class WithdrawAdviceRouterConnector @Inject() (
 
     httpClient
       .put(url"$url")
-      .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .withContentType
       .withAcceptHeader
       .withBody(Json.toJson(request.body))
       .withClientId

--- a/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/CreateRecordControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/CreateRecordControllerIntegrationSpec.scala
@@ -114,6 +114,7 @@ class CreateRecordControllerIntegrationSpec
           postRequestedFor(urlEqualTo(routerUrl))
             .withHeader("Content-Type", equalTo("application/json"))
             .withHeader("X-Client-ID", equalTo("clientId"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
         )
       }
     }
@@ -131,6 +132,7 @@ class CreateRecordControllerIntegrationSpec
           postRequestedFor(urlEqualTo(routerUrl))
             .withHeader("Content-Type", equalTo("application/json"))
             .withHeader("X-Client-ID", equalTo("clientId"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
         )
       }
     }

--- a/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/GetRecordsControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofiles/controllers/GetRecordsControllerIntegrationSpec.scala
@@ -116,6 +116,7 @@ class GetRecordsControllerIntegrationSpec
         verify(
           getRequestedFor(urlEqualTo(getSingleRecordRouterUrl))
             .withHeader("X-Client-ID", equalTo("clientId"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
         )
       }
     }
@@ -284,6 +285,7 @@ class GetRecordsControllerIntegrationSpec
         verify(
           getRequestedFor(urlEqualTo(getMultipleRecordsRouterUrl))
             .withHeader("X-Client-ID", equalTo("clientId"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
         )
       }
     }

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/AdviceRouterConnectorSpec.scala
@@ -77,6 +77,7 @@ class AdviceRouterConnectorSpec extends BaseConnectorSpec with ScalaFutures with
         UrlPath.parse(s"$serverUrl/trader-goods-profiles-router/traders/$eori/records/$recordId/advice")
       verify(httpClient).post(eqTo(url"$expectedUrl"))(any)
       verify(requestBuilder).setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      verify(requestBuilder).setHeader("Accept"                 -> "application/vnd.hmrc.1.0+json")
       verify(requestBuilder).setHeader("X-Client-ID"            -> "clientId")
       verify(requestBuilder).withBody(eqTo(requestAdviceData))(any, any, any)
       verify(requestBuilder).execute(any, any)

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/CreateRecordRouterConnectorSpec.scala
@@ -73,6 +73,7 @@ class CreateRecordRouterConnectorSpec
         val expectedUrl = UrlPath.parse(s"$serverUrl/trader-goods-profiles-router/traders/$eori/records")
         verify(httpClient).post(eqTo(url"$expectedUrl"))(any)
         verify(requestBuilder).setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+        verify(requestBuilder).setHeader("Accept"                 -> "application/vnd.hmrc.1.0+json")
         verify(requestBuilder).setHeader("X-Client-ID"            -> "clientId")
         verify(requestBuilder).withBody(eqTo(createRouterCreateRecordRequestData))(any, any, any)
         verify(requestBuilder).execute(any, any)

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnectorSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterEach, EitherValues}
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
+import uk.gov.hmrc.http.StringContextOps
 import uk.gov.hmrc.tradergoodsprofiles.controllers.support.responses.GetRecordResponseSupport
 import uk.gov.hmrc.tradergoodsprofiles.models.errors.{ErrorResponse, ServiceError}
 import uk.gov.hmrc.tradergoodsprofiles.models.response.{GetRecordResponse, GetRecordsResponse}

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/GetRecordsRouterConnectorSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterEach, EitherValues}
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import uk.gov.hmrc.http.StringContextOps
+import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
 import uk.gov.hmrc.tradergoodsprofiles.controllers.support.responses.GetRecordResponseSupport
 import uk.gov.hmrc.tradergoodsprofiles.models.errors.{ErrorResponse, ServiceError}
 import uk.gov.hmrc.tradergoodsprofiles.models.response.{GetRecordResponse, GetRecordsResponse}
@@ -70,6 +70,7 @@ class GetRecordsRouterConnectorSpec
         val expectedUrl =
           UrlPath.parse(s"$serverUrl/trader-goods-profiles-router/traders/$eori/records/$recordId")
         verify(httpClient).get(eqTo(url"$expectedUrl"))(any)
+        verify(requestBuilder).setHeader("Accept"      -> "application/vnd.hmrc.1.0+json")
         verify(requestBuilder).setHeader("X-Client-ID" -> "clientId")
         verify(requestBuilder).execute(any, any)
       }
@@ -117,6 +118,7 @@ class GetRecordsRouterConnectorSpec
         val expectedUrl =
           UrlPath.parse(s"http://localhost:23123/trader-goods-profiles-router/traders/$eori/records")
         verify(httpClient).get(eqTo(url"$expectedUrl"))(any)
+        verify(requestBuilder).setHeader("Accept"      -> "application/vnd.hmrc.1.0+json")
         verify(requestBuilder).setHeader("X-Client-ID" -> "clientId")
         verify(requestBuilder).execute(any, any)
       }

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/MaintainProfileRouterConnectorSpec.scala
@@ -76,6 +76,7 @@ class MaintainProfileRouterConnectorSpec
           UrlPath.parse(s"$serverUrl/trader-goods-profiles-router/traders/$eori")
         verify(httpClient).put(eqTo(url"$expectedUrl"))(any)
         verify(requestBuilder).setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+        verify(requestBuilder).setHeader("Accept"                 -> "application/vnd.hmrc.1.0+json")
         verify(requestBuilder).withBody(eqTo(updateProfileRequestData))(any, any, any)
         verify(requestBuilder).execute(any, any)
       }

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/RemoveRecordRouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/RemoveRecordRouterConnectorSpec.scala
@@ -65,6 +65,7 @@ class RemoveRecordRouterConnectorSpec
           s"$serverUrl/trader-goods-profiles-router/traders/$eori/records/$recordId?actorId=$actorId"
         verify(httpClient).delete(eqTo(url"$expectedUrl"))(any)
         verify(requestBuilder).setHeader("X-Client-ID" -> "clientId")
+        verify(requestBuilder).setHeader("Accept"      -> "application/vnd.hmrc.1.0+json")
         verify(requestBuilder).execute(any, any)
       }
     }

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/UpdateRecordRouterConnectorSpec.scala
@@ -74,6 +74,7 @@ class UpdateRecordRouterConnectorSpec
           UrlPath.parse(s"$serverUrl/trader-goods-profiles-router/traders/$eori/records/$recordId")
         verify(httpClient).patch(eqTo(url"$expectedUrl"))(any)
         verify(requestBuilder).setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+        verify(requestBuilder).setHeader("Accept"                 -> "application/vnd.hmrc.1.0+json")
         verify(requestBuilder).setHeader("X-Client-ID"            -> "clientId")
         verify(requestBuilder).withBody(eqTo(createUpdateRecordRequestData))(any, any, any)
         verify(requestBuilder).execute(any, any)

--- a/test/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/connectors/WithdrawAdviceRouterConnectorSpec.scala
@@ -80,6 +80,7 @@ class WithdrawAdviceRouterConnectorSpec
         UrlPath.parse(s"$serverUrl/trader-goods-profiles-router/traders/$eori/records/$recordId/advice")
       verify(httpClient).put(eqTo(url"$expectedUrl"))(any)
       verify(requestBuilder).setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      verify(requestBuilder).setHeader("Accept"                 -> "application/vnd.hmrc.1.0+json")
       verify(requestBuilder).setHeader("X-Client-ID"            -> "clientId")
       verify(requestBuilder).withBody(eqTo(withdrawAdviceData))(any, any, any)
       verify(requestBuilder).execute(any, any)

--- a/test/uk/gov/hmrc/tradergoodsprofiles/support/BaseConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/support/BaseConnectorSpec.scala
@@ -20,6 +20,7 @@ import io.lemonlabs.uri.Url
 import org.mockito.MockitoSugar.when
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.PlaySpec
+import play.mvc.Http.HeaderNames
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.tradergoodsprofiles.config.AppConfig
@@ -32,7 +33,9 @@ import scala.concurrent.ExecutionContext
 class BaseConnectorSpec extends PlaySpec {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
-  implicit val hc: HeaderCarrier    = HeaderCarrier(otherHeaders = Seq(XClientIdHeader -> "clientId"))
+  implicit val hc: HeaderCarrier    = HeaderCarrier(otherHeaders =
+    Seq(XClientIdHeader -> "clientId", HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+  )
 
   protected val httpClient     = mock[HttpClientV2]
   protected val appConfig      = mock[AppConfig]

--- a/test/uk/gov/hmrc/tradergoodsprofiles/support/BaseConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofiles/support/BaseConnectorSpec.scala
@@ -20,6 +20,7 @@ import io.lemonlabs.uri.Url
 import org.mockito.MockitoSugar.when
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.PlaySpec
+import play.api.http.MimeTypes
 import play.mvc.Http.HeaderNames
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
@@ -34,7 +35,11 @@ class BaseConnectorSpec extends PlaySpec {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val hc: HeaderCarrier    = HeaderCarrier(otherHeaders =
-    Seq(XClientIdHeader -> "clientId", HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+    Seq(
+      XClientIdHeader          -> "clientId",
+      HeaderNames.ACCEPT       -> "application/vnd.hmrc.1.0+json",
+      HeaderNames.CONTENT_TYPE -> MimeTypes.JSON
+    )
   )
 
   protected val httpClient     = mock[HttpClientV2]


### PR DESCRIPTION
### Description
The API-test pipeline was failing because the external API wasn't able to pass the required Accept header to the router. This caused the router to reject the requests due to missing or incorrect headers. We didn't noticed that issue because the  header is passed explicitly in integration tests. 

**Solution:**
To resolve this issue, we ensured that the Accept header is explicitly passed to the router request.

---

Additionally, the Content-Type header in each connector that uses it has been updated. Now the header is extracted from the HeaderCarrier. 